### PR TITLE
Fix: status bar overlapping on iPhoneX

### DIFF
--- a/Pod/Classes/LinearProgressBar.swift
+++ b/Pod/Classes/LinearProgressBar.swift
@@ -26,7 +26,7 @@ open class LinearProgressBar: UIView {
     open var widthForLinearBar: CGFloat = 0
     
     public init () {
-        super.init(frame: CGRect(origin: CGPoint(x: 0,y :20), size: CGSize(width: screenSize.width, height: 0)))
+        super.init(frame: CGRect(origin: CGPoint(x: 0, y: UIApplication.shared.statusBarFrame.height), size: CGSize(width: screenSize.width, height: 0)))
         self.progressBarIndicator = UIView(frame: CGRect(origin: CGPoint(x: 0,y :0), size: CGSize(width: 0, height: heightForLinearBar)))
     }
     


### PR DESCRIPTION
Due to hardcoded y origin point the
progress bar was overlapping with the
status bar on iPhoneX . Now in the
modified code it get calculates the
height of status bar and set the y-origin
accouding to that.

Fixes #12